### PR TITLE
style(prescriptions): increase font size for timestamp in order pdf

### DIFF
--- a/app/views/clinic_management/prescriptions/order_pdf.html.erb
+++ b/app/views/clinic_management/prescriptions/order_pdf.html.erb
@@ -15,7 +15,7 @@
   <div class="container">
     <span style="font-size: 70px"><b><%= sprintf("%02d", @order_number) %></b></span>
     <p style="font-size: 30px;">Sua ordem da fila</p>
-    <p style="font-size: 20px;"><%= Time.current.strftime("%d/%m/%Y, %H:%M") %>h</p>
+    <p style="font-size: 25px;"><%= Time.current.strftime("%d/%m/%Y, %H:%M") %>h</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
This commit increases the font size of the timestamp displayed in the order PDF within the clinic management prescriptions view. The change is to enhance readability and emphasis of the timestamp for the user.