### PR TITLE
feat(clinic_management): update prescription retrieval logic

### DIFF
--- a/app/controllers/clinic_management/prescriptions_controller.rb
+++ b/app/controllers/clinic_management/prescriptions_controller.rb
@@ -9,7 +9,8 @@ module ClinicManagement
     end
 
     def index_today
-      @service = Service.find_by(date: Date.today)
+      # get the last service
+      @service = Service.where(date: Date.today).last
       if @service.present?
         @appointments = @service.appointments.sort_by { |ap| ap&.invitation&.patient_name }  
         @rows = @appointments.map.with_index(1) do |ap, index|


### PR DESCRIPTION
This commit updates the 'index_today' method in the 'prescriptions_controller' of the 'clinic_management' module. Previously, it used to fetch the first service scheduled for today. The updated logic now retrieves the last service scheduled for today. This change will ensure that the most recent data is rendered when showing today's appointments and prescriptions.