### PR TITLE
feat: Exclude leads with attendance within the last year in leads_con…

### DIFF
--- a/app/controllers/clinic_management/leads_controller.rb
+++ b/app/controllers/clinic_management/leads_controller.rb
@@ -195,20 +195,27 @@ module ClinicManagement
         # Data de um ano atrás a partir de hoje
         one_year_ago = Date.today - 1.year
       
+        # IDs dos leads que tiveram attendance como true dentro do último ano
+        excluded_lead_ids = ClinicManagement::Appointment.joins(:service)
+                                                         .where('clinic_management_appointments.attendance = ? AND clinic_management_services.date >= ?', true, one_year_ago)
+                                                         .pluck(:lead_id)
+      
         if date
           ClinicManagement::Lead.joins(appointments: :service)
                                 .where(query_condition, value, date)
                                 .where('last_appointment_id IN (?)', ClinicManagement::Appointment.joins(:service).where(query_condition, value, date).pluck(:id))
-                                .where.not(id: ClinicManagement::Appointment.where('attendance = ? AND date >= ?', true, one_year_ago).select(:lead_id))
+                                .where.not(id: excluded_lead_ids)
                                 .order('clinic_management_services.date DESC')
         else
           ClinicManagement::Lead.joins(appointments: :service)
                                 .where(id: ClinicManagement::Appointment.where(query_condition, value).select(:lead_id))
                                 .where('last_appointment_id IN (?)', ClinicManagement::Appointment.where(query_condition, value).pluck(:id))
-                                .where.not(id: ClinicManagement::Appointment.where('attendance = ? AND date >= ?', true, one_year_ago).select(:lead_id))
+                                .where.not(id: excluded_lead_ids)
                                 .order('clinic_management_services.date DESC')
         end
       end
+      
+      
       
       
       


### PR DESCRIPTION
…troller

The code changes in leads_controller.rb include excluding leads that have had attendance within the last year. This is achieved by retrieving the IDs of leads with attendance as true within the last year and excluding them from the query results. The commit message suggests adding this exclusion logic to improve the functionality of the leads_controller.